### PR TITLE
call DBG() for external entry points

### DIFF
--- a/src/gallium/state_trackers/nine/basetexture9.c
+++ b/src/gallium/state_trackers/nine/basetexture9.c
@@ -51,6 +51,9 @@ NineBaseTexture9_ctor( struct NineBaseTexture9 *This,
         (format != D3DFMT_NULL);
     HRESULT hr;
 
+    DBG("This=%p, pParams=%p initResource=%p Type=%d format=%d Pool=%d Usage=%d\n",
+        This, pParams, initResource, Type, format, Pool, Usage);
+
     user_assert(!(Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)) ||
                 Pool == D3DPOOL_DEFAULT, D3DERR_INVALIDCALL);
     user_assert(!(Usage & D3DUSAGE_DYNAMIC) ||
@@ -93,6 +96,8 @@ NineBaseTexture9_SetLOD( struct NineBaseTexture9 *This,
 {
     DWORD old = This->lod;
 
+    DBG("This=%p LODNew=%d\n", This, LODNew);
+
     user_assert(This->base.pool == D3DPOOL_MANAGED, 0);
 
     This->lod = MIN2(LODNew, This->base.info.last_level);
@@ -106,12 +111,16 @@ NineBaseTexture9_SetLOD( struct NineBaseTexture9 *This,
 DWORD WINAPI
 NineBaseTexture9_GetLOD( struct NineBaseTexture9 *This )
 {
+    DBG("This=%p\n", This);
+
     return This->lod;
 }
 
 DWORD WINAPI
 NineBaseTexture9_GetLevelCount( struct NineBaseTexture9 *This )
 {
+    DBG("This=%p\n", This);
+
     if (This->base.usage & D3DUSAGE_AUTOGENMIPMAP)
         return 1;
     return This->base.info.last_level + 1;
@@ -121,6 +130,8 @@ HRESULT WINAPI
 NineBaseTexture9_SetAutoGenFilterType( struct NineBaseTexture9 *This,
                                        D3DTEXTUREFILTERTYPE FilterType )
 {
+    DBG("This=%p FilterType=%d\n", This, FilterType);
+
     if (!(This->base.usage & D3DUSAGE_AUTOGENMIPMAP))
         return D3D_OK;
     user_assert(FilterType != D3DTEXF_NONE, D3DERR_INVALIDCALL);
@@ -133,6 +144,8 @@ NineBaseTexture9_SetAutoGenFilterType( struct NineBaseTexture9 *This,
 D3DTEXTUREFILTERTYPE WINAPI
 NineBaseTexture9_GetAutoGenFilterType( struct NineBaseTexture9 *This )
 {
+    DBG("This=%p\n", This);
+
     return This->mipfilter;
 }
 
@@ -433,6 +446,8 @@ NineBaseTexture9_UpdateSamplerView( struct NineBaseTexture9 *This,
     struct pipe_sampler_view templ;
     uint8_t swizzle[4];
 
+    DBG("This=%p sRGB=%d\n", This, sRGB);
+
     if (unlikely(!resource)) {
 	if (unlikely(This->format == D3DFMT_NULL))
             return D3D_OK;
@@ -485,6 +500,8 @@ NineBaseTexture9_UpdateSamplerView( struct NineBaseTexture9 *This,
 void WINAPI
 NineBaseTexture9_PreLoad( struct NineBaseTexture9 *This )
 {
+    DBG("This=%p\n", This);
+
     if (This->dirty && This->base.pool == D3DPOOL_MANAGED)
         NineBaseTexture9_UploadSelf(This);
 }

--- a/src/gallium/state_trackers/nine/cubetexture9.c
+++ b/src/gallium/state_trackers/nine/cubetexture9.c
@@ -42,6 +42,11 @@ NineCubeTexture9_ctor( struct NineCubeTexture9 *This,
     D3DSURFACE_DESC sfdesc;
     HRESULT hr;
 
+    DBG("This=%p pParams=%p EdgeLength=%u Levels=%u Usage=%d "
+        "Format=%d Pool=%d pSharedHandle=%p\n",
+        This, pParams, EdgeLength, Levels, Usage,
+        Format, Pool, pSharedHandle);
+
     user_assert(!(Usage & D3DUSAGE_AUTOGENMIPMAP) ||
                 (Pool != D3DPOOL_SYSTEMMEM && Levels <= 1), D3DERR_INVALIDCALL);
 
@@ -135,6 +140,8 @@ NineCubeTexture9_GetLevelDesc( struct NineCubeTexture9 *This,
                                UINT Level,
                                D3DSURFACE_DESC *pDesc )
 {
+    DBG("This=%p Level=%u pDesc=%p\n", This, Level, pDesc);
+
     user_assert(Level <= This->base.base.info.last_level, D3DERR_INVALIDCALL);
     user_assert(Level == 0 || !(This->base.base.usage & D3DUSAGE_AUTOGENMIPMAP),
                 D3DERR_INVALIDCALL);
@@ -151,6 +158,9 @@ NineCubeTexture9_GetCubeMapSurface( struct NineCubeTexture9 *This,
                                     IDirect3DSurface9 **ppCubeMapSurface )
 {
     const unsigned s = Level * 6 + FaceType;
+
+    DBG("This=%p FaceType=%d Level=%u ppCubeMapSurface=%p\n",
+        This, FaceType, Level, ppCubeMapSurface);
 
     user_assert(Level <= This->base.base.info.last_level, D3DERR_INVALIDCALL);
     user_assert(Level == 0 || !(This->base.base.usage & D3DUSAGE_AUTOGENMIPMAP),
@@ -173,6 +183,9 @@ NineCubeTexture9_LockRect( struct NineCubeTexture9 *This,
 {
     const unsigned s = Level * 6 + FaceType;
 
+    DBG("This=%p FaceType=%d Level=%u pLockedRect=%p pRect=%p Flags=%d\n",
+        This, FaceType, Level, pLockedRect, pRect, Flags);
+
     user_assert(Level <= This->base.base.info.last_level, D3DERR_INVALIDCALL);
     user_assert(Level == 0 || !(This->base.base.usage & D3DUSAGE_AUTOGENMIPMAP),
                 D3DERR_INVALIDCALL);
@@ -188,6 +201,8 @@ NineCubeTexture9_UnlockRect( struct NineCubeTexture9 *This,
 {
     const unsigned s = Level * 6 + FaceType;
 
+    DBG("This=%p FaceType=%d Level=%u\n", This, FaceType, Level);
+
     user_assert(Level <= This->base.base.info.last_level, D3DERR_INVALIDCALL);
     user_assert(FaceType < 6, D3DERR_INVALIDCALL);
 
@@ -199,6 +214,8 @@ NineCubeTexture9_AddDirtyRect( struct NineCubeTexture9 *This,
                                D3DCUBEMAP_FACES FaceType,
                                const RECT *pDirtyRect )
 {
+    DBG("This=%p FaceType=%d pDirtyRect=%p\n", This, FaceType, pDirtyRect);
+
     user_assert(FaceType < 6, D3DERR_INVALIDCALL);
 
     if (This->base.base.pool != D3DPOOL_MANAGED) {

--- a/src/gallium/state_trackers/nine/device9.c
+++ b/src/gallium/state_trackers/nine/device9.c
@@ -58,6 +58,8 @@ NineDevice9_SetDefaultState( struct NineDevice9 *This, boolean is_reset )
 {
     struct NineSurface9 *refSurf = NULL;
 
+    DBG("This=%p is_reset=%d\n", This, (int) is_reset);
+
     assert(!This->is_recording);
 
     nine_state_set_defaults(&This->state, &This->caps, is_reset);
@@ -93,6 +95,8 @@ void
 NineDevice9_RestoreNonCSOState( struct NineDevice9 *This, unsigned mask )
 {
     struct pipe_context *pipe = This->pipe;
+
+    DBG("This=%p mask=%u\n", This, mask);
 
     if (mask & 0x1) {
         struct pipe_constant_buffer cb;
@@ -145,6 +149,12 @@ NineDevice9_ctor( struct NineDevice9 *This,
 {
     unsigned i;
     HRESULT hr = NineUnknown_ctor(&This->base, pParams);
+
+    DBG("This=%p pParams=%p pScreen=%p pCreationParameters=%p pCaps=%p pPresentationParameters=%p "
+        "pD3D9=%p pPresentationGroup=%p pCTX=%p ex=%d pFullscreenDisplayMode=%p\n",
+        This, pParams, pScreen, pCreationParameters, pCaps, pPresentationParameters, pD3D9,
+        pPresentationGroup, pCTX, (int) ex, pFullscreenDisplayMode);
+
     if (FAILED(hr)) { return hr; }
 
     list_inithead(&This->update_textures);
@@ -536,6 +546,8 @@ NineDevice9_SetCursorPosition( struct NineDevice9 *This,
 {
     struct NineSwapChain9 *swap = This->swapchains[0];
 
+    DBG("This=%p X=%d Y=%d Flags=%d\n", This, X, Y, Flags);
+
     This->cursor.pos.x = X;
     This->cursor.pos.y = Y;
 
@@ -548,6 +560,9 @@ NineDevice9_ShowCursor( struct NineDevice9 *This,
                         BOOL bShow )
 {
     BOOL old = This->cursor.visible;
+
+    DBG("This=%p bShow=%d\n", This, (int) bShow);
+
     This->cursor.visible = bShow && (This->cursor.hotspot.x != -1);
     if (!This->cursor.software)
         ID3DPresent_SetCursor(This->swapchains[0]->present, NULL, NULL, bShow);
@@ -563,6 +578,9 @@ NineDevice9_CreateAdditionalSwapChain( struct NineDevice9 *This,
     struct NineSwapChain9 *swapchain, *tmplt = This->swapchains[0];
     ID3DPresent *present;
     HRESULT hr;
+
+    DBG("This=%p pPresentationParameters=%p pSwapChain=%p\n",
+        This, pPresentationParameters, pSwapChain);
 
     user_assert(pPresentationParameters, D3DERR_INVALIDCALL);
 
@@ -640,6 +658,9 @@ NineDevice9_Present( struct NineDevice9 *This,
 {
     unsigned i;
     HRESULT hr;
+
+    DBG("This=%p pSourceRect=%p pDestRect=%p hDestWindowOverride=%p pDirtyRegion=%p\n",
+        This, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
 
     /* XXX is this right? */
     for (i = 0; i < This->nswapchains; ++i) {
@@ -1710,6 +1731,9 @@ NineDevice9_SetTransform( struct NineDevice9 *This,
 {
     struct nine_state *state = This->update;
     D3DMATRIX *M = nine_state_access_transform(state, State, TRUE);
+
+    DBG("This=%p State=%d pMatrix=%p\n", This, State, pMatrix);
+
     user_assert(M, D3DERR_INVALIDCALL);
 
     *M = *pMatrix;
@@ -1738,6 +1762,9 @@ NineDevice9_MultiplyTransform( struct NineDevice9 *This,
     struct nine_state *state = This->update;
     D3DMATRIX T;
     D3DMATRIX *M = nine_state_access_transform(state, State, TRUE);
+
+    DBG("This=%p State=%d pMatrix=%p\n", This, State, pMatrix);
+
     user_assert(M, D3DERR_INVALIDCALL);
 
     nine_d3d_matrix_matrix_mul(&T, pMatrix, M);
@@ -2656,6 +2683,11 @@ NineDevice9_ProcessVertices( struct NineDevice9 *This,
     HRESULT hr;
     unsigned buffer_offset, buffer_size;
 
+    DBG("This=%p SrcStartIndex=%u DestIndex=%u VertexCount=%u "
+        "pDestBuffer=%p pVertexDecl=%p Flags=%d\n",
+        This, SrcStartIndex, DestIndex, VertexCount, pDestBuffer,
+        pVertexDecl, Flags);
+
     if (!screen->get_param(screen, PIPE_CAP_MAX_STREAM_OUTPUT_BUFFERS))
         STUB(D3DERR_INVALIDCALL);
 
@@ -2733,6 +2765,9 @@ NineDevice9_CreateVertexDeclaration( struct NineDevice9 *This,
 {
     struct NineVertexDeclaration9 *vdecl;
 
+    DBG("This=%p pVertexElements=%p ppDecl=%p\n",
+        This, pVertexElements, ppDecl);
+
     HRESULT hr = NineVertexDeclaration9_new(This, pVertexElements, &vdecl);
     if (SUCCEEDED(hr))
         *ppDecl = (IDirect3DVertexDeclaration9 *)vdecl;
@@ -2808,6 +2843,8 @@ NineDevice9_CreateVertexShader( struct NineDevice9 *This,
 {
     struct NineVertexShader9 *vs;
     HRESULT hr;
+
+    DBG("This=%p pFunction=%p ppShader=%p\n", This, pFunction, ppShader);
 
     hr = NineVertexShader9_new(This, &vs, pFunction, NULL);
     if (FAILED(hr))
@@ -2989,6 +3026,9 @@ NineDevice9_SetStreamSource( struct NineDevice9 *This,
     struct NineVertexBuffer9 *pVBuf9 = NineVertexBuffer9(pStreamData);
     const unsigned i = StreamNumber;
 
+    DBG("This=%p StreamNumber=%u pStreamData=%p OffsetInBytes=%u Stride=%u\n",
+        This, StreamNumber, pStreamData, OffsetInBytes, Stride);
+
     user_assert(StreamNumber < This->caps.MaxStreams, D3DERR_INVALIDCALL);
     user_assert(Stride <= This->caps.MaxStreamStride, D3DERR_INVALIDCALL);
 
@@ -3076,6 +3116,8 @@ NineDevice9_SetIndices( struct NineDevice9 *This,
 {
     struct nine_state *state = This->update;
 
+    DBG("This=%p pIndexData=%p\n", This, pIndexData);
+
     if (likely(!This->is_recording))
         if (state->idxbuf == NineIndexBuffer9(pIndexData))
             return D3D_OK;
@@ -3106,6 +3148,8 @@ NineDevice9_CreatePixelShader( struct NineDevice9 *This,
 {
     struct NinePixelShader9 *ps;
     HRESULT hr;
+
+    DBG("This=%p pFunction=%p ppShader=%p\n", This, pFunction, ppShader);
 
     hr = NinePixelShader9_new(This, &ps, pFunction, NULL);
     if (FAILED(hr))
@@ -3308,6 +3352,8 @@ NineDevice9_CreateQuery( struct NineDevice9 *This,
 {
     struct NineQuery9 *query;
     HRESULT hr;
+
+    DBG("This=%p Type=%d ppQuery=%p\n", This, Type, ppQuery);
 
     if (!ppQuery)
         return nine_is_query_supported(Type);

--- a/src/gallium/state_trackers/nine/device9ex.c
+++ b/src/gallium/state_trackers/nine/device9ex.c
@@ -39,6 +39,13 @@ NineDevice9Ex_ctor( struct NineDevice9Ex *This,
                     ID3DPresentGroup *pPresentationGroup,
                     struct d3dadapter9_context *pCTX )
 {
+    DBG("This=%p pParams=%p pScreen=%p pCreationParameters=%p pCaps=%p "
+        "pPresentationParameters=%p pFullscreenDisplayMode=%p "
+        "pD3D9Ex=%p pPresentationGroup=%p pCTX=%p\n",
+        This, pParams, pScreen, pCreationParameters, pCaps,
+        pPresentationParameters, pFullscreenDisplayMode,
+        pD3D9Ex, pPresentationGroup, pCTX);
+
     return NineDevice9_ctor(&This->base, pParams,
                             pScreen, pCreationParameters, pCaps,
                             pPresentationParameters,
@@ -86,6 +93,11 @@ NineDevice9Ex_PresentEx( struct NineDevice9Ex *This,
 {
     unsigned i;
     HRESULT hr;
+
+    DBG("This=%p pSourceRect=%p pDestRect=%p hDestWindowOverride=%p "
+        "pDirtyRegion=%p dwFlags=%d\n",
+        This, pSourceRect, pDestRect, hDestWindowOverride,
+        pDirtyRegion, dwFlags);
 
     for (i = 0; i < This->base.nswapchains; i++) {
         hr = NineSwapChain9_Present(This->base.swapchains[i], pSourceRect, pDestRect,
@@ -226,6 +238,9 @@ NineDevice9Ex_GetDisplayModeEx( struct NineDevice9Ex *This,
                                 D3DDISPLAYROTATION *pRotation )
 {
     struct NineSwapChain9Ex *swapchain;
+
+    DBG("This=%p iSwapChain=%u pMode=%p pRotation=%p\n",
+        This, iSwapChain, pMode, pRotation);
 
     user_assert(iSwapChain < This->base.nswapchains, D3DERR_INVALIDCALL);
 

--- a/src/gallium/state_trackers/nine/iunknown.c
+++ b/src/gallium/state_trackers/nine/iunknown.c
@@ -58,6 +58,8 @@ NineUnknown_QueryInterface( struct NineUnknown *This,
 {
     unsigned i = 0;
 
+    DBG("This=%p riid=%p ppvObject=%p\n", This, riid, ppvObject);
+
     if (!ppvObject) return E_POINTER;
 
     do {

--- a/src/gallium/state_trackers/nine/pixelshader9.c
+++ b/src/gallium/state_trackers/nine/pixelshader9.c
@@ -39,6 +39,8 @@ NinePixelShader9_ctor( struct NinePixelShader9 *This,
     struct nine_shader_info info;
     HRESULT hr;
 
+    DBG("This=%p pParams=%p pFunction=%p cso=%p\n", This, pParams, pFunction, cso);
+
     hr = NineUnknown_ctor(&This->base, pParams);
     if (FAILED(hr))
         return hr;
@@ -110,6 +112,8 @@ NinePixelShader9_GetFunction( struct NinePixelShader9 *This,
                               void *pData,
                               UINT *pSizeOfData )
 {
+    DBG("This=%p pData=%p pSizeOfData=%p\n", This, pData, pSizeOfData);
+
     user_assert(pSizeOfData, D3DERR_INVALIDCALL);
 
     if (!pData) {

--- a/src/gallium/state_trackers/nine/query9.c
+++ b/src/gallium/state_trackers/nine/query9.c
@@ -107,6 +107,8 @@ NineQuery9_ctor( struct NineQuery9 *This,
     const unsigned ptype = d3dquerytype_to_pipe_query(Type);
     HRESULT hr;
 
+    DBG("This=%p pParams=%p Type=%d\n", This, pParams, Type);
+
     hr = NineUnknown_ctor(&This->base, pParams);
     if (FAILED(hr))
         return hr;
@@ -170,6 +172,8 @@ NineQuery9_Issue( struct NineQuery9 *This,
 {
     struct pipe_context *pipe = This->base.device->pipe;
 
+    DBG("This=%p dwIssueFlags=%d\n", This, dwIssueFlags);
+
     user_assert((dwIssueFlags == D3DISSUE_BEGIN && !This->instant) ||
                 (dwIssueFlags == 0) ||
                 (dwIssueFlags == D3DISSUE_END), D3DERR_INVALIDCALL);
@@ -220,6 +224,9 @@ NineQuery9_GetData( struct NineQuery9 *This,
     unsigned i;
     union pipe_query_result presult;
     union nine_query_result nresult;
+
+    DBG("This=%p pData=%p dwSize=%d dwGetDataFlags=%d\n",
+        This, pData, dwSize, dwGetDataFlags);
 
     user_assert(This->state != NINE_QUERY_STATE_RUNNING, D3DERR_INVALIDCALL);
     user_assert(dwSize == 0 || pData, D3DERR_INVALIDCALL);

--- a/src/gallium/state_trackers/nine/resource9.c
+++ b/src/gallium/state_trackers/nine/resource9.c
@@ -46,6 +46,14 @@ NineResource9_ctor( struct NineResource9 *This,
 {
     struct pipe_screen *screen;
     HRESULT hr;
+    
+    DBG("This=%p pParams=%p initResource=%p Allocate=%d "
+        "Type=%d Pool=%d Usage=%d\n",
+        This, pParams, initResource, (int) Allocate,
+        Type, Pool, Usage);
+
+    DBG("This=%p pParams=%p initResource=%p Allocate=%d Type=%d Pool=%d usage=%d\n",
+        This, pParams, initResource, Allocate, Type, Pool, Usage);
 
     hr = NineUnknown_ctor(&This->base, pParams);
     if (FAILED(hr))
@@ -202,6 +210,9 @@ NineResource9_SetPriority( struct NineResource9 *This,
                            DWORD PriorityNew )
 {
     DWORD prev = This->priority;
+
+    DBG("This=%p, PriorityNew=%d\n", This, PriorityNew);
+
     This->priority = PriorityNew;
     return prev;
 }

--- a/src/gallium/state_trackers/nine/stateblock9.c
+++ b/src/gallium/state_trackers/nine/stateblock9.c
@@ -35,6 +35,9 @@ NineStateBlock9_ctor( struct NineStateBlock9 *This,
                       enum nine_stateblock_type type )
 {
     HRESULT hr = NineUnknown_ctor(&This->base, pParams);
+
+    DBG("This=%p pParams=%p type=%d\n", This, pParams, type);
+
     if (FAILED(hr))
         return hr;
 

--- a/src/gallium/state_trackers/nine/surface9.c
+++ b/src/gallium/state_trackers/nine/surface9.c
@@ -250,6 +250,8 @@ NineSurface9_AddDirtyRect( struct NineSurface9 *This,
     float area[2];
     struct u_rect rect, cover_a, cover_b;
 
+    DBG("This=%p box=%p\n", This, box);
+
     if (!box) {
         This->dirty_rects[0].x0 = 0;
         This->dirty_rects[0].y0 = 0;
@@ -471,6 +473,9 @@ NineSurface9_CopySurface( struct NineSurface9 *This,
     uint8_t *p_dst;
     const uint8_t *p_src;
 
+    DBG("This=%p From=%p pDestPoint=%p pSourceRect=%p\n",
+        This, From, pDestPoint, pSourceRect);
+
     user_assert(This->desc.Format == From->desc.Format, D3DERR_INVALIDCALL);
 
     dst_box.x = pDestPoint ? pDestPoint->x : 0;
@@ -585,6 +590,8 @@ NineSurface9_UploadSelf( struct NineSurface9 *This )
     struct pipe_resource *res = This->base.resource;
     uint8_t *ptr;
     unsigned i;
+
+    DBG("This=%p\n", This);
 
     assert(This->base.pool == D3DPOOL_MANAGED);
 

--- a/src/gallium/state_trackers/nine/swapchain9.c
+++ b/src/gallium/state_trackers/nine/swapchain9.c
@@ -737,6 +737,11 @@ NineSwapChain9_Present( struct NineSwapChain9 *This,
     HRESULT hr = present(This, pSourceRect, pDestRect,
                          hDestWindowOverride, pDirtyRegion, dwFlags);
 
+    DBG("This=%p pSourceRect=%p pDestRect=%p hDestWindowOverride=%p "
+        "pDirtyRegion=%p dwFlags=%d\n",
+        This, pSourceRect, pDestRect, hDestWindowOverride,
+        pDirtyRegion,dwFlags);
+
     if (hr == D3DERR_WASSTILLDRAWING)
         return hr;
 

--- a/src/gallium/state_trackers/nine/swapchain9ex.c
+++ b/src/gallium/state_trackers/nine/swapchain9ex.c
@@ -37,6 +37,10 @@ NineSwapChain9Ex_ctor( struct NineSwapChain9Ex *This,
                        HWND hFocusWindow,
                        D3DDISPLAYMODEEX *mode )
 {
+    DBG("This=%p pParams=%p implicit=%d pPresent=%p pPresentationParameters=%p "
+        "pCTX=%p hFocusWindow=%p mode=%p",
+        This, pParams, (int) implicit, pPresent, pPresentationParameters, pCTX, hFocusWindow, mode);
+
     return NineSwapChain9_ctor(&This->base, pParams, implicit, pPresent,
                                pPresentationParameters, pCTX, hFocusWindow, mode);
 }

--- a/src/gallium/state_trackers/nine/texture9.c
+++ b/src/gallium/state_trackers/nine/texture9.c
@@ -226,6 +226,9 @@ NineTexture9_LockRect( struct NineTexture9 *This,
                        const RECT *pRect,
                        DWORD Flags )
 {
+    DBG("This=%p Level=%u pLockedRect=%p pRect=%p Flags=%d\n",
+        This, Level, pLockedRect, pRect, Flags);
+
     user_assert(Level <= This->base.base.info.last_level, D3DERR_INVALIDCALL);
     user_assert(Level == 0 || !(This->base.base.usage & D3DUSAGE_AUTOGENMIPMAP),
                 D3DERR_INVALIDCALL);
@@ -238,6 +241,8 @@ HRESULT WINAPI
 NineTexture9_UnlockRect( struct NineTexture9 *This,
                          UINT Level )
 {
+    DBG("This=%p Level=%u\n", This, Level);
+
     user_assert(Level <= This->base.base.info.last_level, D3DERR_INVALIDCALL);
 
     return NineSurface9_UnlockRect(This->surfaces[Level]);

--- a/src/gallium/state_trackers/nine/vertexdeclaration9.c
+++ b/src/gallium/state_trackers/nine/vertexdeclaration9.c
@@ -210,6 +210,8 @@ NineVertexDeclaration9_ctor( struct NineVertexDeclaration9 *This,
     const D3DCAPS9 *caps;
     unsigned i;
 
+    DBG("This=%p pParams=%p pElements=%p\n", This, pParams, pElements);
+
     HRESULT hr = NineUnknown_ctor(&This->base, pParams);
     if (FAILED(hr)) { return hr; }
 
@@ -459,6 +461,9 @@ NineVertexDeclaration9_ConvertStreamOutput(
     unsigned i;
     void *src_map;
     void *dst_map;
+
+    DBG("This=%p pDstBuf=%p DestIndex=%u VertexCount=%u pSrcBuf=%p so=%p\n",
+        This, pDstBuf, DestIndex, VertexCount, pSrcBuf, so);
 
     transkey.output_stride = 0;
     for (i = 0; i < This->nelems; ++i) {

--- a/src/gallium/state_trackers/nine/vertexshader9.c
+++ b/src/gallium/state_trackers/nine/vertexshader9.c
@@ -40,6 +40,9 @@ NineVertexShader9_ctor( struct NineVertexShader9 *This,
     HRESULT hr;
     unsigned i;
 
+    DBG("This=%p pParams=%p pFunction=%p cso=%p\n",
+        This, pParams, pFunction, cso);
+
     hr = NineUnknown_ctor(&This->base, pParams);
     if (FAILED(hr))
         return hr;

--- a/src/gallium/state_trackers/nine/volume9.c
+++ b/src/gallium/state_trackers/nine/volume9.c
@@ -342,6 +342,9 @@ NineVolume9_CopyVolume( struct NineVolume9 *This,
     uint8_t *p_dst;
     const uint8_t *p_src;
 
+    DBG("This=%p From=%p dstx=%u dsty=%u dstz=%u pSrcBox=%p\n",
+        This, From, dstx, dsty, dstz, pSrcBox);
+
     user_assert(This->desc.Format == From->desc.Format, D3DERR_INVALIDCALL);
 
     dst_box.x = dstx;
@@ -527,6 +530,9 @@ NineVolume9_SetPrivateData( struct NineVolume9 *This,
     struct pheader *header;
     const void *user_data = pData;
 
+    DBG("This=%p refguid=%p pData=%p SizeOfData=%d Flags=%d\n",
+        This, refguid, pData, SizeOfData, Flags);
+
     if (Flags & D3DSPD_IUNKNOWN)
         user_assert(SizeOfData == sizeof(IUnknown *), D3DERR_INVALIDCALL);
 
@@ -592,6 +598,8 @@ NineVolume9_FreePrivateData( struct NineVolume9 *This,
                              REFGUID refguid )
 {
     struct pheader *header;
+
+    DBG("This=%p refguid=%p\n", This, refguid);
 
     header = util_hash_table_get(This->pdata, refguid);
     if (!header) { return D3DERR_NOTFOUND; }

--- a/src/gallium/state_trackers/nine/volumetexture9.c
+++ b/src/gallium/state_trackers/nine/volumetexture9.c
@@ -41,6 +41,11 @@ NineVolumeTexture9_ctor( struct NineVolumeTexture9 *This,
     D3DVOLUME_DESC voldesc;
     HRESULT hr;
 
+    DBG("This=%p pParams=%p Width=%u Height=%u Depth=%u Levels=%u "
+        "Usage=%d Format=%d Pool=%d pSharedHandle=%p\n",
+        This, pParams, Width, Height, Depth, Levels,
+        Usage, Format, Pool, pSharedHandle);
+
     /* An IDirect3DVolume9 cannot be bound as a render target can it ? */
     user_assert(!(Usage & (D3DUSAGE_RENDERTARGET | D3DUSAGE_DEPTHSTENCIL)),
                 D3DERR_INVALIDCALL);
@@ -156,6 +161,9 @@ NineVolumeTexture9_LockBox( struct NineVolumeTexture9 *This,
                             const D3DBOX *pBox,
                             DWORD Flags )
 {
+    DBG("This=%p Level=%u pLockedVolume=%p pBox=%p Flags=%d\n",
+        This, Level, pLockedVolume, pBox, Flags);
+
     user_assert(Level <= This->base.base.info.last_level, D3DERR_INVALIDCALL);
     user_assert(Level == 0 || !(This->base.base.usage & D3DUSAGE_AUTOGENMIPMAP),
                 D3DERR_INVALIDCALL);
@@ -168,6 +176,8 @@ HRESULT WINAPI
 NineVolumeTexture9_UnlockBox( struct NineVolumeTexture9 *This,
                               UINT Level )
 {
+    DBG("This=%p Level=%u\n", This, Level);
+
     user_assert(Level <= This->base.base.info.last_level, D3DERR_INVALIDCALL);
 
     return NineVolume9_UnlockBox(This->volumes[Level]);
@@ -177,6 +187,8 @@ HRESULT WINAPI
 NineVolumeTexture9_AddDirtyBox( struct NineVolumeTexture9 *This,
                                 const D3DBOX *pDirtyBox )
 {
+    DBG("This=%p pDirtybox=%p\n", This, pDirtyBox);
+
     if (This->base.base.pool != D3DPOOL_MANAGED) {
         if (This->base.base.usage & D3DUSAGE_AUTOGENMIPMAP)
             This->base.dirty_mip = TRUE;


### PR DESCRIPTION
As existing convention, simple getters and short functions not annotated.
