### PR TITLE
nine: handle D3DISSUE_END without previous D3DISSUE_BEGIN

### DIFF
--- a/src/gallium/state_trackers/nine/query9.c
+++ b/src/gallium/state_trackers/nine/query9.c
@@ -188,8 +188,8 @@ NineQuery9_Issue( struct NineQuery9 *This,
     } else {
         if (This->state == NINE_QUERY_STATE_RUNNING) {
             pipe->end_query(pipe, This->pq);
-            This->state = NINE_QUERY_STATE_ENDED;
 	}
+	This->state = NINE_QUERY_STATE_ENDED;
     }
     return D3D_OK;
 }


### PR DESCRIPTION
This patch fixes black screen with games based on the Unreal Engine 3.
It was tested that it fixed the issue in Tera Online, Borderlands 2 and Homefront.

Reviewed-by: Axel Davy axel.davy@ens.fr
Reviewed-by: David Heidelberg david@ixit.cz
Signed-off-by: John Ettedgui john.ettedgui@gmail.com
