### PR TITLE
st/nine: fix D3DRS_POINTSPRITE support, by testing the existence of the ...

### DIFF
--- a/src/gallium/state_trackers/nine/nine_shader.c
+++ b/src/gallium/state_trackers/nine/nine_shader.c
@@ -2945,9 +2945,6 @@ nine_translate_shader(struct NineDevice9 *device, struct nine_shader_info *info)
             ureg_property(tx->ureg, TGSI_PROPERTY_FS_COORD_PIXEL_CENTER, TGSI_FS_COORD_PIXEL_CENTER_INTEGER);
     }
 
-    if (!ureg_dst_is_undef(tx->regs.oPts))
-        info->point_size = TRUE;
-
     while (!sm1_parse_eof(tx))
         sm1_parse_instruction(tx);
     tx->parse++; /* for byte_size */
@@ -2962,6 +2959,9 @@ nine_translate_shader(struct NineDevice9 *device, struct nine_shader_info *info)
         ureg_property(tx->ureg, TGSI_PROPERTY_VS_WINDOW_SPACE_POSITION, TRUE);
 
     ureg_END(tx->ureg);
+
+    if (IS_VS && !ureg_dst_is_undef(tx->regs.oPts))
+        info->point_size = TRUE;
 
     if (debug_get_bool_option("NINE_TGSI_DUMP", FALSE)) {
         unsigned count;


### PR DESCRIPTION
...point sprite output register _after_ parsing the vertex shader.

Signed-off-by: Xavier Bouchoux xavierb@gmail.com
