### PR TITLE
st/nine: Don't increment refcount on failure

### DIFF
--- a/src/gallium/state_trackers/nine/vertexdeclaration9.c
+++ b/src/gallium/state_trackers/nine/vertexdeclaration9.c
@@ -174,24 +174,24 @@ NineVertexDeclaration9_ctor( struct NineVertexDeclaration9 *This,
                              const D3DVERTEXELEMENT9 *pElements )
 {
     const D3DCAPS9 *caps;
-    unsigned i;
-
+    unsigned i, nelems;
     DBG("This=%p pParams=%p pElements=%p\n", This, pParams, pElements);
+
+    /* wine */
+    for (nelems = 0;
+         pElements[nelems].Stream != 0xFF;
+         ++nelems) {
+        user_assert(pElements[nelems].Type != D3DDECLTYPE_UNUSED, E_FAIL);
+        user_assert(!(pElements[nelems].Offset & 3), E_FAIL);
+    }
+
+    caps = NineDevice9_GetCaps(pParams->device);
+    user_assert(nelems <= caps->MaxStreams, D3DERR_INVALIDCALL);
 
     HRESULT hr = NineUnknown_ctor(&This->base, pParams);
     if (FAILED(hr)) { return hr; }
 
-    /* wine */
-    for (This->nelems = 0;
-         pElements[This->nelems].Stream != 0xFF;
-         ++This->nelems) {
-        user_assert(pElements[This->nelems].Type != D3DDECLTYPE_UNUSED, E_FAIL);
-        user_assert(!(pElements[This->nelems].Offset & 3), E_FAIL);
-    }
-
-    caps = NineDevice9_GetCaps(This->base.device);
-    user_assert(This->nelems <= caps->MaxStreams, D3DERR_INVALIDCALL);
-
+    This->nelems = nelems;
     This->decls = CALLOC(This->nelems+1, sizeof(D3DVERTEXELEMENT9));
     This->elems = CALLOC(This->nelems, sizeof(struct pipe_vertex_element));
     This->usage_map = CALLOC(This->nelems, sizeof(uint16_t));


### PR DESCRIPTION
NineUnknown_ctor increments the refcount even in case of an error.
Re-structure the code to prevent refcount increments.
Fixes a couple of wine tests.

Signed-off-by: Patrick Rudolph <siro@das-labor.org>