### PR TITLE
st/nine: Check for window occlusion in swapchain::present() too

### DIFF
--- a/src/gallium/state_trackers/nine/device9.c
+++ b/src/gallium/state_trackers/nine/device9.c
@@ -813,12 +813,6 @@ NineDevice9_Present( struct NineDevice9 *This,
     DBG("This=%p pSourceRect=%p pDestRect=%p hDestWindowOverride=%p pDirtyRegion=%p\n",
         This, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
 
-    if (NineSwapChain9_GetOccluded(This->swapchains[0])) {
-        This->device_needs_reset = TRUE;
-    }
-
-    user_assert(!This->device_needs_reset, D3DERR_DEVICELOST);
-
     /* XXX is this right? */
     for (i = 0; i < This->nswapchains; ++i) {
         hr = NineSwapChain9_Present(This->swapchains[i], pSourceRect, pDestRect,

--- a/src/gallium/state_trackers/nine/device9ex.c
+++ b/src/gallium/state_trackers/nine/device9ex.c
@@ -100,12 +100,6 @@ NineDevice9Ex_PresentEx( struct NineDevice9Ex *This,
         This, pSourceRect, pDestRect, hDestWindowOverride,
         pDirtyRegion, dwFlags);
 
-
-    if (NineSwapChain9_GetOccluded(This->base.swapchains[0])) {
-        return S_PRESENT_OCCLUDED;
-    }
-
-
     for (i = 0; i < This->base.nswapchains; i++) {
         hr = NineSwapChain9_Present(This->base.swapchains[i], pSourceRect, pDestRect,
                                     hDestWindowOverride, pDirtyRegion, dwFlags);
@@ -124,9 +118,6 @@ NineDevice9Ex_Present( struct NineDevice9Ex *This,
 {
     DBG("This=%p pSourceRect=%p pDestRect=%p hDestWindowOverride=%p pDirtyRegion=%p\n",
         This, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
-    if (NineSwapChain9_GetOccluded(This->base.swapchains[0])) {
-        return S_PRESENT_OCCLUDED;
-    }
 
     return NineDevice9_Present(&This->base, pSourceRect, pDestRect,
                                hDestWindowOverride, pDirtyRegion);

--- a/src/gallium/state_trackers/nine/swapchain9.c
+++ b/src/gallium/state_trackers/nine/swapchain9.c
@@ -783,6 +783,19 @@ NineSwapChain9_Present( struct NineSwapChain9 *This,
     if (hr == D3DERR_WASSTILLDRAWING)
         return hr;
 
+    if (This->base.device->ex) {
+        if (NineSwapChain9_GetOccluded(This)) {
+            return S_PRESENT_OCCLUDED;
+        }
+    } else {
+        if (NineSwapChain9_GetOccluded(This)) {
+            This->base.device->device_needs_reset = TRUE;
+        }
+        if (This->base.device->device_needs_reset) {
+            return D3DERR_DEVICELOST;
+        }
+    }
+
     switch (This->params.SwapEffect) {
         case D3DSWAPEFFECT_FLIP:
             UNTESTED(4);


### PR DESCRIPTION
Some applications call swapchain::present() instead of device::present().
Test for occlusion in swapchain::present() and return appropiate error codes.

Fixes resolution changes on Alt+Tab for this applications:
* Battlefield: Bad Company 2
* FarCry 2

Signed-off-by: Patrick Rudolph <siro@das-labor.org>