### PR TITLE
nvc0/state: Fix regression

### DIFF
--- a/src/gallium/drivers/nouveau/nvc0/nvc0_state.c
+++ b/src/gallium/drivers/nouveau/nvc0/nvc0_state.c
@@ -698,8 +698,11 @@ nvc0_cp_state_create(struct pipe_context *pipe,
 
    prog->pipe.tokens = tgsi_dup_tokens((const struct tgsi_token *)cso->prog);
 
+   bool half_pixel_center = nvc0_context(pipe)->rast ?
+      nvc0_context(pipe)->rast->pipe.half_pixel_center : true;
    prog->translated = nvc0_program_translate(
-      prog, nvc0_context(pipe)->screen->base.device->chipset,
+      prog, half_pixel_center,
+      nvc0_context(pipe)->screen->base.device->chipset,
       &nouveau_context(pipe)->debug);
 
    return (void *)prog;


### PR DESCRIPTION
Upstream changes broke nouveau build.
Merge with " v50,nvc0: fix frag coord when half-pixel center is disabled "

Signed-off-by: Patrick Rudolph <siro@das-labor.org>