### PR TITLE
st/nine: Optimize nine_csmt_process

### DIFF
--- a/src/gallium/state_trackers/nine/nine_queue.c
+++ b/src/gallium/state_trackers/nine/nine_queue.c
@@ -200,6 +200,17 @@ nine_queue_alloc(struct nine_queue_pool* ctx, unsigned space)
     return cmdbuf->mem_pool + offset;
 }
 
+/* Returns the current queue empty state.
+ * TRUE no instructions queued.
+ * FALSE one ore more instructions queued. */
+bool
+nine_queue_isempty(struct nine_queue_pool* ctx)
+{
+    struct nine_cmdbuf *cmdbuf = &ctx->pool[ctx->head];
+
+    return (ctx->tail == ctx->head) && !cmdbuf->num_instr;
+}
+
 struct nine_queue_pool*
 nine_queue_create(void)
 {

--- a/src/gallium/state_trackers/nine/nine_queue.h
+++ b/src/gallium/state_trackers/nine/nine_queue.h
@@ -39,6 +39,9 @@ nine_queue_flush(struct nine_queue_pool* ctx);
 void *
 nine_queue_alloc(struct nine_queue_pool* ctx, unsigned space);
 
+bool
+nine_queue_isempty(struct nine_queue_pool* ctx);
+
 struct nine_queue_pool*
 nine_queue_create(void);
 

--- a/src/gallium/state_trackers/nine/nine_state.c
+++ b/src/gallium/state_trackers/nine/nine_state.c
@@ -176,6 +176,9 @@ nine_csmt_process( struct NineDevice9 *device )
     if (!device->csmt_active)
         return;
 
+    if (nine_queue_isempty(ctx->pool))
+        return;
+
     DBG("device=%p\n", device);
 
     /* NOP */


### PR DESCRIPTION
Exit early on empty queue.
Prevents one round trip to worker thread and back again.

Signed-off-by: Patrick Rudolph <siro@das-labor.org>