### PR TITLE
Dirty region related fixes

### DIFF
--- a/src/gallium/state_trackers/nine/buffer9.c
+++ b/src/gallium/state_trackers/nine/buffer9.c
@@ -242,8 +242,13 @@ NineBuffer9_Lock( struct NineBuffer9 *This,
                 This->managed.dirty_box = box;
                 if (p_atomic_read(&This->managed.pending_upload))
                     nine_csmt_process(This->base.base.device);
-            } else
-                u_box_union_2d(&This->managed.dirty_box, &This->managed.dirty_box, &box);
+            } else {
+                if (This->managed.dirty_box.width == 0) {
+                    memcpy(&This->managed.dirty_box, &box, sizeof(struct pipe_box));
+                } else {
+                    u_box_union_2d(&This->managed.dirty_box, &This->managed.dirty_box, &box);
+                }
+            }
             /* Tests trying to draw while the buffer is locked show that
              * MANAGED buffers are made dirty at Lock time */
             BASEBUF_REGISTER_UPDATE(This);

--- a/src/gallium/state_trackers/nine/cubetexture9.c
+++ b/src/gallium/state_trackers/nine/cubetexture9.c
@@ -285,10 +285,14 @@ NineCubeTexture9_AddDirtyRect( struct NineCubeTexture9 *This,
                         This->base.base.info.height0,
                         &This->dirty_rect[FaceType]);
     } else {
-        struct pipe_box box;
-        rect_to_pipe_box_clamp(&box, pDirtyRect);
-        u_box_union_2d(&This->dirty_rect[FaceType], &This->dirty_rect[FaceType],
-                       &box);
+        if (This->dirty_rect[FaceType].width == 0) {
+            rect_to_pipe_box_clamp(&This->dirty_rect[FaceType], pDirtyRect);
+        } else {
+            struct pipe_box box;
+            rect_to_pipe_box_clamp(&box, pDirtyRect);
+            u_box_union_2d(&This->dirty_rect[FaceType], &This->dirty_rect[FaceType],
+                           &box);
+        }
         (void) u_box_clip_2d(&This->dirty_rect[FaceType],
                              &This->dirty_rect[FaceType],
                              This->base.base.info.width0,

--- a/src/gallium/state_trackers/nine/texture9.c
+++ b/src/gallium/state_trackers/nine/texture9.c
@@ -330,9 +330,13 @@ NineTexture9_AddDirtyRect( struct NineTexture9 *This,
         u_box_origin_2d(This->base.base.info.width0,
                         This->base.base.info.height0, &This->dirty_rect);
     } else {
-        struct pipe_box box;
-        rect_to_pipe_box_clamp(&box, pDirtyRect);
-        u_box_union_2d(&This->dirty_rect, &This->dirty_rect, &box);
+        if (This->dirty_rect.width == 0) {
+            rect_to_pipe_box_clamp(&This->dirty_rect, pDirtyRect);
+        } else {
+            struct pipe_box box;
+            rect_to_pipe_box_clamp(&box, pDirtyRect);
+            u_box_union_2d(&This->dirty_rect, &This->dirty_rect, &box);
+        }
         (void) u_box_clip_2d(&This->dirty_rect, &This->dirty_rect,
                              This->base.base.info.width0,
                              This->base.base.info.height0);

--- a/src/gallium/state_trackers/nine/volumetexture9.c
+++ b/src/gallium/state_trackers/nine/volumetexture9.c
@@ -222,9 +222,13 @@ NineVolumeTexture9_AddDirtyBox( struct NineVolumeTexture9 *This,
         This->dirty_box.height = This->base.base.info.height0;
         This->dirty_box.depth = This->base.base.info.depth0;
     } else {
-        struct pipe_box box;
-        d3dbox_to_pipe_box(&box, pDirtyBox);
-        u_box_union_3d(&This->dirty_box, &This->dirty_box, &box);
+        if (This->dirty_box.width == 0) {
+            d3dbox_to_pipe_box(&This->dirty_box, pDirtyBox);
+        } else {
+            struct pipe_box box;
+            d3dbox_to_pipe_box(&box, pDirtyBox);
+            u_box_union_3d(&This->dirty_box, &This->dirty_box, &box);
+        }
         This->dirty_box.x = MAX2(This->dirty_box.x, 0);
         This->dirty_box.y = MAX2(This->dirty_box.y, 0);
         This->dirty_box.z = MAX2(This->dirty_box.z, 0);


### PR DESCRIPTION
* <del>Return D3DERR_INVALIDCALL when an invalid rect is passed to NineTexture9_AddDirtyRect()</del>
* Don't call u_box_union_* when dirty region is empty
    * This fixes broken font rendering issue in WOLF RPG Editor v2.10 games